### PR TITLE
Close tab in current window only

### DIFF
--- a/scripts/background.js
+++ b/scripts/background.js
@@ -4,7 +4,7 @@ chrome.runtime.onMessage.addListener(
     // check the message command for a close tab command
     if (request.command === "close_tab")
         // find the currently active tab
-        chrome.tabs.query({ active: true }, function(tabs) {
+        chrome.tabs.query({ active: true, currentWindow: true }, function(tabs) {
             // close the found tab
             chrome.tabs.remove(tabs[0].id);
         });


### PR DESCRIPTION
Fixes bug report from webstore reported by Danijel Milisic.

Background script was not querying for active tab **in current window** so i imaging it was defaulting to first window opened.