### PR TITLE
Focus previously focused tab

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,14 @@
 {
   "manifest_version": 3,
   "name": "AWS VPN Tab Closer",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "An extension to detect and close the authentication tab left open by AWS VPN",
   "background": {
     "service_worker": "scripts/background.js"
   },
+  "permissions": [
+    "tabs"
+  ],
   "content_scripts": [
     {
       "js": [

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -1,10 +1,28 @@
-// listen for messages
-chrome.runtime.onMessage.addListener(
-    function(request, sender, sendResponse) {
-//        console.log(request, sender);
-        // check the message command for a close tab command
-        if (request.command === "close_tab")
-            chrome.tabs.remove(sender.tab.id);
+const tabFocusHistory = new Map();
 
+chrome.tabs.onActivated.addListener((activeInfo) => {
+  tabFocusHistory.set(activeInfo.tabId, Date.now());
+});
+
+chrome.tabs.onRemoved.addListener((tabId) => {
+  tabFocusHistory.delete(tabId);
+});
+
+chrome.runtime.onMessage.addListener(
+  function(request, sender, sendResponse) {
+    if (request.command === "close_tab" && sender.tab) {
+      chrome.tabs.query({ active: true, currentWindow: true }, async (tabs) => {
+        if (tabs[0]?.id === sender.tab.id) {
+          // Find the most recently focused tab (excluding current)
+          const sortedTabs = Array.from(tabFocusHistory.entries())
+                .filter(([tabId]) => tabId !== sender.tab.id)
+                .sort(([, a], [, b]) => b - a);
+          if (sortedTabs.length > 0) {
+            await chrome.tabs.update(sortedTabs[0][0], { active: true });
+          }
+        }
+        chrome.tabs.remove(sender.tab.id);
+      });
     }
+  }
 );


### PR DESCRIPTION
Previously the tab immediately to the left would be focused. With this change extension maintains history of focused tabs and on closing focuces the previous tab, resulding in better user experience.